### PR TITLE
missing the required permission_callback argument

### DIFF
--- a/includes/api/crosswordengine-api.php
+++ b/includes/api/crosswordengine-api.php
@@ -11,6 +11,7 @@ class CrosswordEngineAPI {
         register_rest_route( 'crosswordengine/v1', '/crosswords', [
             'methods' => 'GET',
             'callback' => [ $this, 'get_crosswords' ],
+			'permission_callback' => '__return_true'
         ]);
     }
 


### PR DESCRIPTION
The REST API route definition for crosswordengine/v1/crosswords is missing the required permission_callback argument.